### PR TITLE
feat(core): add robust health check endpoint with modular service checks

### DIFF
--- a/core/tests/test_health_check.py
+++ b/core/tests/test_health_check.py
@@ -1,0 +1,132 @@
+from django.test import TestCase
+from rest_framework.test import APITestCase
+from rest_framework import status
+from unittest.mock import patch, MagicMock
+from django.conf import settings
+import os
+
+from core.views import HealthCheckView
+
+
+class HealthCheckViewTest(APITestCase):
+    def setUp(self):
+        self.url = '/core/health/'
+        # Ensure no OpenAI key for some tests
+        if 'OPENAI_API_KEY' in os.environ:
+            del os.environ['OPENAI_API_KEY']
+
+    @patch('core.views.connection.cursor')
+    @patch('core.views.Redis.from_url')
+    @patch('core.views.OpenAI')
+    def test_health_check_all_healthy(self, mock_openai, mock_redis, mock_cursor):
+        # Mock DB success
+        mock_cursor_instance = MagicMock()
+        mock_cursor.return_value.__enter__.return_value = mock_cursor_instance
+        mock_cursor_instance.execute.return_value = None
+
+        # Mock Redis success
+        mock_redis_instance = MagicMock()
+        mock_redis_instance.ping.return_value = True
+        mock_redis.return_value = mock_redis_instance
+
+        # Mock OpenAI success (key set)
+        os.environ['OPENAI_API_KEY'] = 'test-key'
+        mock_client = MagicMock()
+        mock_client.models.list.return_value = MagicMock()
+        mock_openai.return_value = mock_client
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data['overall'], 'healthy')
+        self.assertEqual(data['services']['db'], 'healthy')
+        self.assertEqual(data['services']['redis'], 'healthy')
+        self.assertEqual(data['services']['openai'], 'healthy')
+
+    @patch('core.views.connection.cursor')
+    @patch('core.views.Redis.from_url')
+    def test_health_check_openai_skipped(self, mock_redis, mock_cursor):
+        # Mock DB and Redis success
+        mock_cursor_instance = MagicMock()
+        mock_cursor.return_value.__enter__.return_value = mock_cursor_instance
+        mock_cursor_instance.execute.return_value = None
+
+        mock_redis_instance = MagicMock()
+        mock_redis_instance.ping.return_value = True
+        mock_redis.return_value = mock_redis_instance
+
+        # No OpenAI key
+        if 'OPENAI_API_KEY' in os.environ:
+            del os.environ['OPENAI_API_KEY']
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data['overall'], 'healthy')
+        self.assertEqual(data['services']['db'], 'healthy')
+        self.assertEqual(data['services']['redis'], 'healthy')
+        self.assertEqual(data['services']['openai'], 'skipped')
+
+    @patch('core.views.connection.cursor')
+    @patch('core.views.Redis.from_url')
+    @patch('core.views.OpenAI')
+    def test_health_check_openai_unhealthy(self, mock_openai, mock_redis, mock_cursor):
+        # Mock DB and Redis success
+        mock_cursor_instance = MagicMock()
+        mock_cursor.return_value.__enter__.return_value = mock_cursor_instance
+        mock_cursor_instance.execute.return_value = None
+
+        mock_redis_instance = MagicMock()
+        mock_redis_instance.ping.return_value = True
+        mock_redis.return_value = mock_redis_instance
+
+        # Mock OpenAI failure
+        os.environ['OPENAI_API_KEY'] = 'test-key'
+        mock_openai.side_effect = Exception('API error')
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data['overall'], 'healthy')
+        self.assertEqual(data['services']['db'], 'healthy')
+        self.assertEqual(data['services']['redis'], 'healthy')
+        self.assertEqual(data['services']['openai'], 'unhealthy')
+
+    @patch('core.views.connection.cursor')
+    @patch('core.views.Redis.from_url')
+    def test_health_check_db_unhealthy(self, mock_redis, mock_cursor):
+        # Mock DB failure
+        mock_cursor.side_effect = Exception('DB error')
+
+        # Mock Redis success
+        mock_redis_instance = MagicMock()
+        mock_redis_instance.ping.return_value = True
+        mock_redis.return_value = mock_redis_instance
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        data = response.json()
+        self.assertEqual(data['overall'], 'unhealthy')
+        self.assertEqual(data['services']['db'], 'unhealthy')
+
+    @patch('core.views.connection.cursor')
+    @patch('core.views.Redis.from_url')
+    def test_health_check_redis_unhealthy(self, mock_redis, mock_cursor):
+        # Mock DB success
+        mock_cursor_instance = MagicMock()
+        mock_cursor.return_value.__enter__.return_value = mock_cursor_instance
+        mock_cursor_instance.execute.return_value = None
+
+        # Mock Redis failure
+        mock_redis.side_effect = Exception('Redis error')
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        data = response.json()
+        self.assertEqual(data['overall'], 'unhealthy')
+        self.assertEqual(data['services']['redis'], 'unhealthy')

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from core.views import CreateCheckoutSessionView, StripeWebhookView, PlanListView, CreateBillingPortalSessionView, VerifyCheckoutSessionView
+from core.views import CreateCheckoutSessionView, StripeWebhookView, PlanListView, CreateBillingPortalSessionView, VerifyCheckoutSessionView, HealthCheckView
 
 router = DefaultRouter()
 
 urlpatterns = [
+    path('health/', HealthCheckView.as_view(), name='health_check'),
     path('payments/create-checkout-session/', CreateCheckoutSessionView.as_view(), name='create_checkout_session'),
     path('payments/webhook/stripe/', StripeWebhookView.as_view(), name='stripe_webhook'),
     path('payments/verify-session/', VerifyCheckoutSessionView.as_view(), name='verify_checkout_session'),


### PR DESCRIPTION
Adds a robust, modular health check endpoint to the core app. The endpoint checks database and Redis connectivity (required), and OpenAI API (optional, only if key is set). Returns a JSON status for each service and an overall health indicator.

- Implements `HealthCheckView` in `core/views.py` using a registry-based approach for extensibility.
- Adds `/core/health/` route in `core/urls.py`.
- DB and Redis are required for "healthy" status; OpenAI is optional.
- Returns HTTP 200 if core services are healthy, with clear JSON output.
- includes comprehensive tests for endpoint and error handling.

<img width="1201" height="597" alt="swagger" src="https://github.com/user-attachments/assets/64b910c8-b02c-4933-9cf7-65a380a31a2d" />


Closes #24