### PR TITLE
Apply Unfold theme to DRF Token, Celery Beat, and Allauth models

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -6,9 +6,23 @@ from unfold.admin import ModelAdmin
 from .models import User, Plan
 from rest_framework.authtoken.admin import TokenAdmin
 from rest_framework.authtoken.models import TokenProxy
+from django_celery_beat.models import (
+    PeriodicTask,
+    IntervalSchedule,
+    CrontabSchedule,
+    SolarSchedule,
+    ClockedSchedule,
+)
+
 
 admin.site.unregister(Group)
 admin.site.unregister(TokenProxy)
+# Unregister default Celery Beat admin
+admin.site.unregister(PeriodicTask)
+admin.site.unregister(IntervalSchedule)
+admin.site.unregister(CrontabSchedule)
+admin.site.unregister(SolarSchedule)
+admin.site.unregister(ClockedSchedule)
 
 @admin.register(User)
 class UserAdmin(BaseUserAdmin, ModelAdmin):
@@ -81,5 +95,31 @@ class GroupAdmin(BaseGroupAdmin, ModelAdmin):
     pass
 
 @admin.register(TokenProxy)
-class TokenAdmin(TokenAdmin,ModelAdmin):
+class TokenAdmin(TokenAdmin, ModelAdmin):
+    pass
+
+
+# Celery Beat Admin with Unfold
+@admin.register(PeriodicTask)
+class PeriodicTaskAdmin(ModelAdmin):
+    pass
+
+
+@admin.register(IntervalSchedule)
+class IntervalScheduleAdmin(ModelAdmin):
+    pass
+
+
+@admin.register(CrontabSchedule)
+class CrontabScheduleAdmin(ModelAdmin):
+    pass
+
+
+@admin.register(SolarSchedule)
+class SolarScheduleAdmin(ModelAdmin):
+    pass
+
+
+@admin.register(ClockedSchedule)
+class ClockedScheduleAdmin(ModelAdmin):
     pass

--- a/core/admin.py
+++ b/core/admin.py
@@ -4,9 +4,11 @@ from django.contrib.auth.models import Group
 from django.utils.translation import gettext_lazy as _
 from unfold.admin import ModelAdmin
 from .models import User, Plan
-
+from rest_framework.authtoken.admin import TokenAdmin
+from rest_framework.authtoken.models import TokenProxy
 
 admin.site.unregister(Group)
+admin.site.unregister(TokenProxy)
 
 @admin.register(User)
 class UserAdmin(BaseUserAdmin, ModelAdmin):
@@ -76,4 +78,8 @@ class PlanAdmin(ModelAdmin):
 
 @admin.register(Group)
 class GroupAdmin(BaseGroupAdmin, ModelAdmin):
+    pass
+
+@admin.register(TokenProxy)
+class TokenAdmin(TokenAdmin,ModelAdmin):
     pass

--- a/core/admin.py
+++ b/core/admin.py
@@ -13,6 +13,7 @@ from django_celery_beat.models import (
     SolarSchedule,
     ClockedSchedule,
 )
+from allauth.socialaccount.models import SocialAccount, SocialApp, SocialToken
 
 
 admin.site.unregister(Group)
@@ -23,6 +24,11 @@ admin.site.unregister(IntervalSchedule)
 admin.site.unregister(CrontabSchedule)
 admin.site.unregister(SolarSchedule)
 admin.site.unregister(ClockedSchedule)
+# Unregister Allauth models
+admin.site.unregister(SocialAccount)
+admin.site.unregister(SocialApp)
+admin.site.unregister(SocialToken)
+
 
 @admin.register(User)
 class UserAdmin(BaseUserAdmin, ModelAdmin):
@@ -123,3 +129,21 @@ class SolarScheduleAdmin(ModelAdmin):
 @admin.register(ClockedSchedule)
 class ClockedScheduleAdmin(ModelAdmin):
     pass
+
+
+# Allauth Admin with Unfold
+@admin.register(SocialAccount)
+class SocialAccountAdmin(ModelAdmin):
+    pass
+
+
+@admin.register(SocialApp)
+class SocialAppAdmin(ModelAdmin):
+    pass
+
+
+@admin.register(SocialToken)
+class SocialTokenAdmin(ModelAdmin):
+    pass
+
+


### PR DESCRIPTION
### Changes
Applied **Unfold** admin theme styling to third-party package models:
- **DRF Authentication**: TokenProxy model
- **Django Celery Beat**: PeriodicTask, IntervalSchedule, CrontabSchedule, SolarSchedule, ClockedSchedule
- **Django Allauth**: SocialAccount, SocialApp, SocialToken

### What was done
- Unregistered default admin classes for these models
- Re-registered with Unfold's `ModelAdmin` to apply dark theme styling
- Maintained all default functionality while providing consistent UI across admin panel

### Benefits
- All admin models now have consistent modern dark theme
- Improved visual experience when managing background tasks and social authentication

### Before: 
<img width="1470" height="831" alt="Screenshot 2025-10-03 at 5 24 18 PM" src="https://github.com/user-attachments/assets/8c6da5f9-2cc6-4192-9652-78da596a75be" />
<img width="1470" height="831" alt="Screenshot 2025-10-03 at 5 24 42 PM" src="https://github.com/user-attachments/assets/f5da9ee2-80f6-456d-8ec6-1be7d6a670c8" />
<img width="1470" height="831" alt="Screenshot 2025-10-03 at 5 25 08 PM" src="https://github.com/user-attachments/assets/be415038-969d-4377-9ad5-30e7c849bb2a" />

### After:
<img width="1470" height="831" alt="Screenshot 2025-10-03 at 5 29 44 PM" src="https://github.com/user-attachments/assets/cd39f71d-3ee7-4e92-830c-803da8313f37" />
<img width="1470" height="831" alt="Screenshot 2025-10-03 at 5 40 38 PM" src="https://github.com/user-attachments/assets/f6b4e324-ce94-49c1-85c7-c277bf4fbbb6" />
<img width="1470" height="831" alt="Screenshot 2025-10-03 at 5 40 49 PM" src="https://github.com/user-attachments/assets/6d6902a8-7145-40a0-ae9e-a198f2c3c0dd" />

Closes #29 