### PR TITLE
ix rate limit history filtering, exempt /core/health , and standardize upgrade URLs

### DIFF
--- a/core/middleware/rate_limit.py
+++ b/core/middleware/rate_limit.py
@@ -25,7 +25,7 @@ class RateLimitMiddleware:
     
     def __call__(self, request):
         # Skip rate limiting for certain paths
-        exempt_paths = ['/admin/', '/static/', '/media/', '/health/']
+        exempt_paths = ['/admin/', '/static/', '/media/', '/health/', '/core/health/']
         if any(request.path.startswith(path) for path in exempt_paths):
             return self.get_response(request)
         

--- a/core/throttling.py
+++ b/core/throttling.py
@@ -110,7 +110,7 @@ class PlanBasedThrottle(UserRateThrottle):
             'message': 'Too many requests. Please try again later.',
             'upgrade_suggestion': {
                 'recommended_plan': recommended_plan,
-                'upgrade_url': '/plans/'
+                'upgrade_url': '/core/plans/'
             } if recommended_plan else None
         })
 
@@ -261,10 +261,9 @@ def get_rate_limit_status(user, scope='ai_responses'):
     cache_key = throttle.get_cache_key(mock_request, None)
     history = cache.get(cache_key, [])
     
-    # Filter to requests within the current window
+    # Filter to requests within the current window (oldest entries removed)
     now = throttle.timer()
-    while history and history[-1] <= now - duration:
-        history.pop()
+    history = [t for t in history if t > now - duration]
     
     used = len(history)
     remaining = max(0, num_requests - used)


### PR DESCRIPTION
- Summary
  - Ensures health checks are never rate-limited, fixes overcounting in rate limit usage, and aligns upgrade URLs used in throttle responses with routed paths.
- Changes
  - core/middleware/rate_limit.py : Add /core/health/ to exempt_paths so health checks bypass rate limiting.
  - core/throttling.py : Correct get_rate_limit_status to filter cached timestamps using a proper window ( t > now - duration ) to prevent inflated usage counts.
  - core/throttling.py : Standardize upgrade_url in throttle responses to '/core/plans/' .
- Why
  - The health endpoint is routed under /core/health/ , but only /health/ was exempt, causing unintended rate limiting.
  - Usage was occasionally misreported due to stale timestamps not being consistently pruned from history.
  - Upgrade URLs were inconsistent across responses, leading to navigational confusion.
- Impact
  - More accurate rate limit status and consistent throttling behavior.
  - No schema or DB changes; low risk to production traffic.
  - Health monitoring becomes reliable under load.
- Affected Endpoints
  - GET /core/health/ (exempted from rate limiting)
  - Throttled endpoints referencing:
    - ai_responses (e.g., POST /cv/ai-responses/ )
    - questionnaires (e.g., POST /cv/questionnaires/ )
    - api_calls (general API traffic)
- Testing Notes
  - Existing rate-limiting tests should continue to pass:
    - Health check accessibility and status structure
    - Throttle counts for free vs. paid plans
    - Upgrade recommendation logic and status labels
  - Suggested local commands:
    - python -m venv .venv && source .venv/bin/activate
    - pip install -r requirements.txt
    - python manage.py test
- Rollout/Monitoring
  - Observe application logs for rate limit events and confirm health checks are unaffected.
  - Optional: validate UI/API consumers correctly follow upgrade_url: '/core/plans/' .
Checklist

- Health endpoint correctly exempted under '/core/health/'
- Rate limit history filtered within active window
- Upgrade URL standardized to '/core/plans/'
- Tests run and pass in CI
- Docs updated if any consumer relies on old upgrade_url path
Related

- cvimprover-api/core/middleware/rate_limit.py
- cvimprover-api/core/throttling.py